### PR TITLE
Publish to Rubygems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ Dir.glob('lib/tasks/*.rake').each { |r| import r }
 
 
 require 'gem_publisher'
-desc 'Publish gem to Gemfury'
+desc 'Publish gem to Rubygems'
 task :publish_gem do
-  gem = GemPublisher.publish_if_updated('optic14n.gemspec', :gemfury, :as => 'govuk')
+  gem = GemPublisher.publish_if_updated('optic14n.gemspec', :rubygems)
   puts "Published #{gem}" if gem
 end
 

--- a/optic14n.gemspec
+++ b/optic14n.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
 
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'gemfury', '~> 0.4.17'
   spec.add_development_dependency 'gem_publisher', '~> 1.3.0'
 end


### PR DESCRIPTION
All public repos should publish to Rubygems rather than GemFury.
