### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 Parse a `BLURI` like this:
 
 ```ruby
-  bluri = URI::BLURI('http://somewhere.com/?a=1&b=2&c=3')
+  bluri = BLURI('http://somewhere.com/?a=1&b=2&c=3')
 ```
 
 Canonicalize it according to the [Previously-Established Rules](#the-previously-established-rules) thusly:


### PR DESCRIPTION
As it was, it would raise an error:

``` ruby
irb(main):014:0> bluri = URI::BLURI('http://somewhere.com/?a=1&b=2&c=3')NoMethodError: private method `BLURI' called for URI:Module
    from (irb):14
    from /usr/bin/irb:12:in `<main>'
```
