### PR TITLE
Pin rspec to 2.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rspec'
+  gem 'rspec', '2.14.1'
 end


### PR DESCRIPTION
Now that rspec 3 is out, CI tries to use that instead and fails on
'its'.
