### PR TITLE
Don't error on unsymbolizable query param keys

### DIFF
--- a/lib/uri/bluri.rb
+++ b/lib/uri/bluri.rb
@@ -79,10 +79,10 @@ module URI
 
     def canonicalize_query!(options)
       allow_all = (options[:allow_query] == :all)
-      allowed_keys = [options[:allow_query]].flatten.compact unless allow_all
+      allowed_keys = [options[:allow_query]].flatten.compact.map(&:to_s) unless allow_all
 
       query_hash.keep_if do |k, _|
-        allow_all || (allowed_keys.include?(k) || allowed_keys.include?(k.to_sym))
+        allow_all || (allowed_keys.include?(k.to_s))
       end
 
       self.query_hash = QueryHash[query_hash.sort_by { |k, _| k }]

--- a/spec/c14n_spec.rb
+++ b/spec/c14n_spec.rb
@@ -148,6 +148,19 @@ describe "Paul's tests, translated from Perl" do
           end
         end
       end
+
+      describe 'indifferent specfication of allowed query params' do
+        context 'specifying the allowed query param using either a symbol or a string' do
+          it 'should behave the same' do
+            url = 'http://example.com/some?significant=1&query_params=2'
+
+            using_symbol = BLURI(url).canonicalize!(allow_query: :significant)
+            using_string = BLURI(url).canonicalize!(allow_query: 'significant')
+
+            using_symbol.should == using_string
+          end
+        end
+      end
     end
 
     describe 'degenerate cases' do
@@ -163,6 +176,10 @@ describe "Paul's tests, translated from Perl" do
           BLURI('http://example.com/path?%ED=view').
             canonicalize!(allow_query: :all).
             to_s.should eql('http://example.com/path?%ED=view')
+        end
+
+        it 'does not error when there are bad things in query keys when allow_query isn\'t :all' do
+          expect { BLURI('http://some.com/a/path?%E2').canonicalize! }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
To fix https://errbit.publishing.service.gov.uk/apps/530f56010da115868600173d/problems/577c047a65786352db2b0400

This error occurs when canonicalizing query strings.  It appears that not every
character emerges unscathed from this process.  In this case, having `%E2`
(which is equivalent to "â")  in a key of a query string results in the error
found in Errbit.

The code path which breaks consists of the query string being parsed into a
hash:

`CGI::parse(self.query)`

(This converts `%E2` to `\xE2`)

`canonicalize_query!` then calls `to_sym` on this value, which throws
`EncodingError: invalid encoding symbol`

Our method for fixing this is to invert the comparison process, converting all
the allowed_query values to strings and comparing these with the string value
of each query hash key.  (Previously it would compare each value, then
symbolize it and attempt to compare it again.)

See https://trello.com/c/ihTQRRMX/325-encoding-error-on-hits-import-in-transition
for further explanation and context.

with @jennyd and @klssmith 