### PR TITLE
Bump version due to changing query handling

### DIFF
--- a/lib/optic14n/version.rb
+++ b/lib/optic14n/version.rb
@@ -1,3 +1,3 @@
 module Optic14n
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
Due to a bug where we can't symbolize some query parameters we've had to
change the way we handle the canonicalization process.