### PR TITLE
Version 2.1.0: prevent URI schemes outside of http/https/mailto

### DIFF
--- a/lib/optic14n/canonicalized_urls.rb
+++ b/lib/optic14n/canonicalized_urls.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module Optic14n
   ##
   # Canonicalizes a set of URLs

--- a/lib/optic14n/version.rb
+++ b/lib/optic14n/version.rb
@@ -1,3 +1,3 @@
 module Optic14n
-  VERSION = "2.0.1".freeze
+  VERSION = "2.1.0".freeze
 end

--- a/lib/uri/bluri.rb
+++ b/lib/uri/bluri.rb
@@ -29,7 +29,14 @@ module URI
 
     def initialize(uri_str)
       @uri = ::Addressable::URI.parse(uri_str)
-      raise URI::InvalidURIError, "'#{uri_str}' not a valid URI" unless @uri
+
+      raise URI::InvalidURIError, "'#{uri_str}' not a valid URI" unless valid_uri?
+    end
+
+    def valid_uri?
+      return unless @uri
+
+      %w[http https mailto].include?(@uri.scheme)
     end
 
     def query_hash

--- a/spec/bluri_spec.rb
+++ b/spec/bluri_spec.rb
@@ -7,7 +7,7 @@ describe URI::BLURI do
   end
 
   it "should not allow other schemes" do
-    lambda { expect(BLURI("ftp://foo")).to raise_error(ArgumentError) }
+    expect { BLURI("ftp://foo") }.to raise_error(URI::InvalidURIError)
   end
 
   it "should not allow nil" do


### PR DESCRIPTION
This PR fixes a broken test. I've added a scheme validation method to the BLURI module, which should only allow URIs beginning with http/https/mailto (the latter is covered by tests elsewhere in this file). This is behaviour that was clearly intended, but incorrectly implemented.

It also bumps from 2.0.1 to 2.1.0 - more than a patch because of potentially breaking changes, but no deliberate API changes (and thus not a major bump).

This commit should fix a resurgence in Sentry errors we're seeing in Bouncer, which relies on optic14n to sanitize its URLs:
https://sentry.io/organizations/govuk/issues/2086648123/?project=202210