### PR TITLE
Fix changelog headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 3.0.2
+# Changelog
+
+## 3.0.2
 
 * Update dependencies
-
-# Changelog
 
 ## 3.0.1
 


### PR DESCRIPTION
I merged the auto-release workflows changes without spotting the messed up headings