### PR TITLE
Split out publish workflow from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: [push, pull_request]
 
 jobs:
@@ -10,7 +12,7 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-  
+
   # This matrix job runs the test suite against multiple Ruby versions
   test_matrix:
     strategy:
@@ -34,12 +36,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "All matrix tests have passed 🚀"
-
-  publish:
-    needs: test
-    if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      contents: write
-    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yml@main
-    secrets:
-      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  publish:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yml@main
+    secrets:
+      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
[Trello](https://trello.com/c/i9P1FYYa/1647-split-publish-ci-step-into-separate-workflow-in-gems)

In our apps we split the release process into its own workflow. The workflow only runs if CI has completed on the main branch

In contrast, in our gems the publish process is a final step of the CI workflow. Though publishing isn't in a separate workflow, it does still depend on the tests passing

Splitting out the publish process into its own workflow like we do with releasing apps would provide a few benefits:
- a finer grain look at failires in GitHub's [actions view][] (without having to open each individual failed run)
- the ability to trigger a publish manually without going through the rest of the CI workflow, should the tests pass but the publish fail, for instance
- the ability to add [failure alerts][] to CI and publishing independently and with different conditions if useful

[actions view]: https://github.com/alphagov/optic14n/actions
[failure alerts]: https://github.com/alphagov/govuk-infrastructure/tree/main/.github/actions/report-run-failure